### PR TITLE
Fix bugs from code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 
 dist/
 .config/
+.idea/
+CLAUDE.md

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,52 @@
+package tinymail
+
+import (
+	"net/smtp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Bug 6: the LOGIN auth mechanism must refuse to send credentials over an
+// unencrypted connection, and must answer the server's challenges robustly
+// regardless of casing or trailing punctuation.
+func TestLoginAuthRefusesUnencrypted(t *testing.T) {
+	test := assert.New(t)
+	a := loginAuth("user", "pass")
+
+	_, _, err := a.Start(&smtp.ServerInfo{Name: "mail.example.com", TLS: false})
+	test.Error(err, "LOGIN auth must not start on an unencrypted connection")
+}
+
+func TestLoginAuthStartsOverTLS(t *testing.T) {
+	test := assert.New(t)
+	a := loginAuth("user", "pass")
+
+	proto, _, err := a.Start(&smtp.ServerInfo{Name: "mail.example.com", TLS: true})
+	test.NoError(err)
+	test.Equal("LOGIN", proto)
+}
+
+func TestLoginAuthAnswersChallenges(t *testing.T) {
+	test := assert.New(t)
+	a := loginAuth("user", "pass")
+	if _, _, err := a.Start(&smtp.ServerInfo{Name: "mail.example.com", TLS: true}); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	cases := []struct {
+		prompt string
+		want   string
+	}{
+		{"Username:", "user"},
+		{"username", "user"},
+		{"Username", "user"},
+		{"Password:", "pass"},
+		{"PASSWORD:", "pass"},
+	}
+	for _, c := range cases {
+		got, err := a.Next([]byte(c.prompt), true)
+		test.NoErrorf(err, "prompt %q", c.prompt)
+		test.Equalf(c.want, string(got), "prompt %q", c.prompt)
+	}
+}

--- a/mail.go
+++ b/mail.go
@@ -17,6 +17,9 @@ import (
 
 const DEFAULT_SMTP_PORT int = 587
 
+// crlf is the RFC 5322 line separator used throughout the serialized message.
+const crlf = "\r\n"
+
 type Mailer interface {
 	Send() error
 	SetBoundary(boundary string)
@@ -134,7 +137,7 @@ func (m *mailer) sendTLS() error {
 		return err
 	}
 
-	for _, rcpt := range m.message.To() {
+	for _, rcpt := range m.recipients() {
 		if err = c.Rcpt(rcpt); err != nil {
 			return err
 		}
@@ -156,7 +159,18 @@ func (m *mailer) sendTLS() error {
 }
 
 func (m *mailer) sendPlain() error {
-	return smtp.SendMail(m.config.addr, m.config.auth, m.config.user, m.message.To(), m.writeMessage())
+	return smtp.SendMail(m.config.addr, m.config.auth, m.config.user, m.recipients(), m.writeMessage())
+}
+
+// recipients returns every envelope recipient: To, CC and BCC. All of them
+// need a RCPT TO, otherwise CC/BCC recipients never receive the message.
+func (m *mailer) recipients() []string {
+	msg := m.message
+	rcpts := make([]string, 0, len(msg.To())+len(msg.CC())+len(msg.BCC()))
+	rcpts = append(rcpts, msg.To()...)
+	rcpts = append(rcpts, msg.CC()...)
+	rcpts = append(rcpts, msg.BCC()...)
+	return rcpts
 }
 
 // SetMessage sets the message
@@ -189,7 +203,7 @@ func (m *mailer) chunkLines(s string) string {
 		chunkedLines = append(chunkedLines, m.chunkString(scanner.Text()))
 	}
 
-	return strings.Join(chunkedLines, "\n")
+	return strings.Join(chunkedLines, crlf)
 }
 
 // chunk e mail into parts of 998 characters due to
@@ -201,58 +215,59 @@ func (m *mailer) chunkString(s string) string {
 		s = s[998:]
 	}
 	chunks = append(chunks, s)
-	return strings.Join(chunks, "\n")
+	return strings.Join(chunks, crlf)
 }
 
-// writeMessage writes the message
+// sanitizeHeader strips CR and LF from a header value to prevent header
+// injection (an attacker-controlled value breaking out into new headers).
+func sanitizeHeader(s string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
+}
+
+// writeMessage serializes the message into RFC 5322 / MIME wire format.
 func (m *mailer) writeMessage() []byte {
 	msg := m.message
 	buf := bytes.NewBuffer(nil)
-	buf.WriteString("MIME-Version: 1.0\n")
 	withAttachments := len(msg.Attachments()) > 0
-	buf.WriteString(fmt.Sprintf("From: %s\n", msg.From()))
-	buf.WriteString(fmt.Sprintf("To: %s\n", strings.Join(msg.To(), ",")))
-	buf.WriteString(fmt.Sprintf("Subject: %s\n", msg.Subject()))
+
+	buf.WriteString("MIME-Version: 1.0" + crlf)
+	buf.WriteString(fmt.Sprintf("From: %s%s", sanitizeHeader(msg.From()), crlf))
+	buf.WriteString(fmt.Sprintf("To: %s%s", sanitizeHeader(strings.Join(msg.To(), ",")), crlf))
+	buf.WriteString(fmt.Sprintf("Subject: %s%s", sanitizeHeader(msg.Subject()), crlf))
 	if len(msg.CC()) > 0 {
-		buf.WriteString(fmt.Sprintf("Cc: %s\n", strings.Join(msg.CC(), ",")))
+		buf.WriteString(fmt.Sprintf("Cc: %s%s", sanitizeHeader(strings.Join(msg.CC(), ",")), crlf))
 	}
-
-	if len(msg.BCC()) > 0 {
-		buf.WriteString(fmt.Sprintf("Bcc: %s\n", strings.Join(msg.BCC(), ",")))
-	}
+	// Bcc is intentionally omitted from the headers: blind recipients must not
+	// be visible to anyone. They are delivered via the SMTP envelope only.
 	if len(msg.Priority()) > 0 {
-		buf.WriteString(fmt.Sprintf("Priority: %s\n", msg.Priority()))
+		buf.WriteString(fmt.Sprintf("Priority: %s%s", sanitizeHeader(msg.Priority()), crlf))
 	}
 
-	writer := multipart.NewWriter(buf)
 	var boundary string
-	if len(m.boundary) > 0 {
+	if withAttachments {
 		boundary = m.boundary
-	} else {
-		boundary = writer.Boundary()
-	}
-
-	if withAttachments {
-		buf.WriteString(fmt.Sprintf("Content-Type: multipart/mixed;\n boundary=%s\n\n", boundary))
-		buf.WriteString(fmt.Sprintf("--%s\n", boundary))
-
-	}
-	buf.WriteString(fmt.Sprintf("Content-Type: %s\n\n", http.DetectContentType([]byte(msg.Body()))))
-	buf.WriteString(m.chunkLines(msg.Body()))
-	if withAttachments {
-		for k, v := range msg.Attachments() {
-			buf.WriteString(fmt.Sprintf("\n--%s\n", boundary))
-			buf.WriteString(fmt.Sprintf("Content-Type: %s\n", http.DetectContentType(v)))
-			buf.WriteString("Content-Transfer-Encoding: base64\n")
-			buf.WriteString(fmt.Sprintf("Content-Disposition: attachment; filename=%s\n\n", k))
-
-			b := make([]byte, base64.StdEncoding.EncodedLen(len(v)))
-			base64.StdEncoding.Encode(b, v)
-			buf.Write([]byte(m.chunkString(string(b))))
-			buf.WriteString(fmt.Sprintf("\n--%s", boundary))
+		if boundary == "" {
+			boundary = multipart.NewWriter(buf).Boundary()
 		}
+		buf.WriteString(fmt.Sprintf("Content-Type: multipart/mixed;%s boundary=%s%s%s", crlf, boundary, crlf, crlf))
+		buf.WriteString(fmt.Sprintf("--%s%s", boundary, crlf))
+	}
 
-		buf.WriteString("--")
+	buf.WriteString(fmt.Sprintf("Content-Type: %s%s%s", http.DetectContentType([]byte(msg.Body())), crlf, crlf))
+	buf.WriteString(m.chunkLines(msg.Body()))
+
+	if withAttachments {
+		for name, content := range msg.Attachments() {
+			buf.WriteString(fmt.Sprintf("%s--%s%s", crlf, boundary, crlf))
+			buf.WriteString(fmt.Sprintf("Content-Type: %s%s", http.DetectContentType(content), crlf))
+			buf.WriteString("Content-Transfer-Encoding: base64" + crlf)
+			buf.WriteString(fmt.Sprintf("Content-Disposition: attachment; filename=%s%s%s", sanitizeHeader(name), crlf, crlf))
+
+			b := make([]byte, base64.StdEncoding.EncodedLen(len(content)))
+			base64.StdEncoding.Encode(b, content)
+			buf.Write([]byte(m.chunkString(string(b))))
+		}
+		buf.WriteString(fmt.Sprintf("%s--%s--", crlf, boundary))
 	}
 	return buf.Bytes()
 }
@@ -262,19 +277,24 @@ func loginAuth(username, password string) smtp.Auth {
 }
 
 func (a *smtpLoginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
-	return "LOGIN", []byte{}, nil
+	if !server.TLS {
+		return "", nil, errors.New("tinymail: refusing to send LOGIN credentials over an unencrypted connection")
+	}
+	return "LOGIN", nil, nil
 }
 
 func (a *smtpLoginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
-	if more {
-		switch string(fromServer) {
-		case "Username:":
-			return []byte(a.username), nil
-		case "Password:":
-			return []byte(a.password), nil
-		default:
-			return nil, errors.New("Unkown fromServer")
-		}
+	if !more {
+		return nil, nil
 	}
-	return nil, nil
+	// Servers phrase the challenge differently ("Username:", "username", ...);
+	// normalize before matching.
+	switch strings.ToLower(strings.TrimRight(strings.TrimSpace(string(fromServer)), ":")) {
+	case "username":
+		return []byte(a.username), nil
+	case "password":
+		return []byte(a.password), nil
+	default:
+		return nil, fmt.Errorf("tinymail: unexpected LOGIN challenge %q", fromServer)
+	}
 }

--- a/mail_test.go
+++ b/mail_test.go
@@ -2,10 +2,17 @@ package tinymail
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// toCRLF rewrites the \n-delimited golden strings below into the CRLF form
+// that writeMessage actually produces (RFC 5322).
+func toCRLF(s string) string {
+	return strings.ReplaceAll(s, "\n", "\r\n")
+}
 
 var VALID_MAILER_OPTS = MailerOpts{
 	User:     "test",
@@ -43,7 +50,6 @@ From: test@tinymail.test
 To: test.to@tinymail.test
 Subject: TestWriteMessage
 Cc: test.cc@tinymail.test
-Bcc: test.bcc@tinymail.test
 Content-Type: text/plain; charset=utf-8
 
 this is a test`
@@ -60,7 +66,7 @@ this is a test`
 
 	mailer.SetMessage(msg)
 
-	test.Equal(want, string(mailer.writeMessage()))
+	test.Equal(toCRLF(want), string(mailer.writeMessage()))
 }
 
 func TestWriteMessageUrgent(t *testing.T) {
@@ -71,7 +77,6 @@ From: test@tinymail.test
 To: test.to@tinymail.test
 Subject: TestWriteMessageUrgent
 Cc: test.cc@tinymail.test
-Bcc: test.bcc@tinymail.test
 Priority: urgent
 Content-Type: text/plain; charset=utf-8
 
@@ -89,7 +94,7 @@ this is a test`
 	msg.SetUrgentPriority()
 
 	mailer.SetMessage(msg)
-	test.Equal(want, string(mailer.writeMessage()))
+	test.Equal(toCRLF(want), string(mailer.writeMessage()))
 }
 
 func TestWriteMessageAttach(t *testing.T) {
@@ -100,7 +105,6 @@ From: test@tinymail.test
 To: test.to@tinymail.test
 Subject: TestWriteMessageAttach
 Cc: test.cc@tinymail.test
-Bcc: test.bcc@tinymail.test
 Content-Type: multipart/mixed;
  boundary=7b7f6c9583aae2870247062aac5ca1bc1610b22b627ae2c5366bb1394ed0
 
@@ -133,7 +137,7 @@ AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 
 	mailer.SetMessage(msg)
 
-	test.Equal(want, string(mailer.writeMessage()))
+	test.Equal(toCRLF(want), string(mailer.writeMessage()))
 	test.NoError(os.Remove("TestWriteMessageAttach"))
 }
 

--- a/mime_test.go
+++ b/mime_test.go
@@ -1,0 +1,76 @@
+package tinymail
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/mail"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Bug 3: a message with multiple attachments must produce a valid
+// multipart/mixed body that parses back into one text part plus one part
+// per attachment.
+func TestWriteMessageMultipleAttachments(t *testing.T) {
+	test := assert.New(t)
+
+	dir := t.TempDir()
+	files := map[string]int{
+		"first.bin":  128,
+		"second.bin": 256,
+		"third.bin":  512,
+	}
+	mailer, err := New(VALID_MAILER_OPTS)
+	test.NoError(err)
+
+	msg := FromString("body text")
+	msg.SetFrom("from@tinymail.test")
+	msg.SetTo("to@tinymail.test")
+	msg.SetSubject("attachments")
+	for name, size := range files {
+		path := filepath.Join(dir, name)
+		test.NoError(os.WriteFile(path, make([]byte, size), 0644))
+		test.NoError(msg.Attach(path))
+	}
+	mailer.SetMessage(msg)
+
+	raw := mailer.writeMessage()
+
+	parsed, err := mail.ReadMessage(bytes.NewReader(raw))
+	require.NoError(t, err)
+
+	mediaType, params, err := mime.ParseMediaType(parsed.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	test.Equal("multipart/mixed", mediaType)
+	test.NotEmpty(params["boundary"])
+
+	mr := multipart.NewReader(parsed.Body, params["boundary"])
+	var textParts, attachmentParts int
+	seen := map[string]bool{}
+	for {
+		part, err := mr.NextPart()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		if part.FileName() != "" {
+			attachmentParts++
+			seen[part.FileName()] = true
+		} else {
+			textParts++
+		}
+		io.Copy(io.Discard, part)
+	}
+
+	test.Equal(1, textParts, "expected exactly one body part")
+	test.Equal(len(files), attachmentParts, "expected one part per attachment")
+	for name := range files {
+		test.True(seen[name], "attachment %q missing from message", name)
+	}
+}

--- a/mock_smtp_test.go
+++ b/mock_smtp_test.go
@@ -1,0 +1,129 @@
+package tinymail
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// mockSMTP is a minimal in-process SMTP server used to capture the SMTP
+// conversation (envelope recipients and the raw DATA payload) so the send
+// paths can be tested without a real mail server.
+type mockSMTP struct {
+	ln net.Listener
+
+	mu       sync.Mutex
+	mailFrom string
+	rcpts    []string
+	data     string
+}
+
+// newMockSMTP starts a mock server on a random loopback port and stops it
+// when the test finishes. The loopback host (127.0.0.1) lets net/smtp's
+// PlainAuth send credentials over the unencrypted test connection.
+func newMockSMTP(t *testing.T) *mockSMTP {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("mock smtp listen: %v", err)
+	}
+	m := &mockSMTP{ln: ln}
+	go m.serve()
+	t.Cleanup(func() { ln.Close() })
+	return m
+}
+
+func (m *mockSMTP) port() int {
+	return m.ln.Addr().(*net.TCPAddr).Port
+}
+
+func (m *mockSMTP) serve() {
+	conn, err := m.ln.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	r := bufio.NewReader(conn)
+	w := bufio.NewWriter(conn)
+	reply := func(s string) {
+		w.WriteString(s + "\r\n")
+		w.Flush()
+	}
+
+	reply("220 mock ready")
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+		cmd := strings.ToUpper(line)
+
+		switch {
+		case strings.HasPrefix(cmd, "EHLO"), strings.HasPrefix(cmd, "HELO"):
+			reply("250-mock greets you")
+			reply("250 AUTH PLAIN LOGIN")
+		case strings.HasPrefix(cmd, "AUTH"):
+			reply("235 2.7.0 authentication succeeded")
+		case strings.HasPrefix(cmd, "MAIL FROM"):
+			m.mu.Lock()
+			m.mailFrom = line
+			m.mu.Unlock()
+			reply("250 2.1.0 ok")
+		case strings.HasPrefix(cmd, "RCPT TO"):
+			m.mu.Lock()
+			m.rcpts = append(m.rcpts, addr(line))
+			m.mu.Unlock()
+			reply("250 2.1.5 ok")
+		case strings.HasPrefix(cmd, "DATA"):
+			reply("354 end data with <CR><LF>.<CR><LF>")
+			var sb strings.Builder
+			for {
+				dl, err := r.ReadString('\n')
+				if err != nil {
+					break
+				}
+				if dl == ".\r\n" || dl == ".\n" {
+					break
+				}
+				sb.WriteString(dl)
+			}
+			m.mu.Lock()
+			m.data = sb.String()
+			m.mu.Unlock()
+			reply("250 2.0.0 ok queued")
+		case strings.HasPrefix(cmd, "QUIT"):
+			reply("221 2.0.0 bye")
+			return
+		default:
+			reply("250 ok")
+		}
+	}
+}
+
+// recipients returns the addresses that received an envelope RCPT TO.
+func (m *mockSMTP) recipients() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.rcpts...)
+}
+
+// body returns the raw DATA payload as received by the server.
+func (m *mockSMTP) body() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.data
+}
+
+// addr extracts the address out of a "RCPT TO:<addr>" command.
+func addr(line string) string {
+	if i := strings.Index(line, "<"); i >= 0 {
+		if j := strings.Index(line, ">"); j > i {
+			return line[i+1 : j]
+		}
+	}
+	return line
+}

--- a/send_test.go
+++ b/send_test.go
@@ -1,0 +1,113 @@
+package tinymail
+
+import (
+	"net/mail"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestMailer wires a mailer to the given mock server. Host must be a
+// loopback literal so PlainAuth allows the unencrypted test connection.
+func newTestMailer(t *testing.T, srv *mockSMTP) *mailer {
+	t.Helper()
+	m, err := New(MailerOpts{
+		User:     "test",
+		Password: "secret",
+		Host:     "127.0.0.1",
+		Port:     srv.port(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return m
+}
+
+// Bug 1: every To/CC/BCC recipient must receive an envelope RCPT TO,
+// otherwise CC and BCC recipients silently never get the mail.
+func TestSendDeliversToAllRecipients(t *testing.T) {
+	test := assert.New(t)
+	srv := newMockSMTP(t)
+
+	msg := FromString("hello")
+	msg.SetFrom("from@tinymail.test")
+	msg.SetTo("to1@tinymail.test", "to2@tinymail.test")
+	msg.SetCC("cc@tinymail.test")
+	msg.SetBCC("bcc@tinymail.test")
+	msg.SetSubject("recipients")
+
+	test.NoError(newTestMailer(t, srv).SetMessage(msg).Send())
+
+	rcpts := srv.recipients()
+	test.ElementsMatch([]string{
+		"to1@tinymail.test",
+		"to2@tinymail.test",
+		"cc@tinymail.test",
+		"bcc@tinymail.test",
+	}, rcpts)
+}
+
+// Bug 2: CC stays visible in the header, but BCC must never appear in the
+// message body delivered to recipients.
+func TestSendDoesNotLeakBCC(t *testing.T) {
+	test := assert.New(t)
+	srv := newMockSMTP(t)
+
+	msg := FromString("hello")
+	msg.SetFrom("from@tinymail.test")
+	msg.SetTo("to@tinymail.test")
+	msg.SetCC("cc@tinymail.test")
+	msg.SetBCC("secret@tinymail.test")
+	msg.SetSubject("bcc")
+
+	test.NoError(newTestMailer(t, srv).SetMessage(msg).Send())
+
+	data := srv.body()
+	test.Contains(data, "Cc: cc@tinymail.test")
+	test.NotContains(data, "Bcc:")
+	test.NotContains(data, "secret@tinymail.test")
+}
+
+// Bug 4: the serialized message must use CRLF line endings per RFC 5322.
+// This is asserted on writeMessage() directly because net/smtp's DotWriter
+// rewrites bare LF to CRLF on the wire, masking the bug at the mock level.
+func TestWriteMessageUsesCRLF(t *testing.T) {
+	test := assert.New(t)
+
+	mailer, err := New(VALID_MAILER_OPTS)
+	test.NoError(err)
+
+	msg := FromString("line one\nline two")
+	msg.SetFrom("from@tinymail.test")
+	msg.SetTo("to@tinymail.test")
+	msg.SetSubject("crlf")
+	mailer.SetMessage(msg)
+
+	data := string(mailer.writeMessage())
+	test.Contains(data, "\r\n")
+	// No bare LF: stripping all CRLF pairs must leave no stray '\n'.
+	test.NotContains(strings.ReplaceAll(data, "\r\n", ""), "\n")
+}
+
+// Bug 5: header fields must not allow injecting extra headers via CR/LF.
+// A CRLF smuggled into the subject must not produce a real Bcc header or an
+// extra envelope recipient.
+func TestSendRejectsHeaderInjection(t *testing.T) {
+	test := assert.New(t)
+	srv := newMockSMTP(t)
+
+	msg := FromString("hello")
+	msg.SetFrom("from@tinymail.test")
+	msg.SetTo("to@tinymail.test")
+	msg.SetSubject("hi\r\nBcc: victim@tinymail.test")
+
+	test.NoError(newTestMailer(t, srv).SetMessage(msg).Send())
+
+	parsed, err := mail.ReadMessage(strings.NewReader(srv.body()))
+	require.NoError(t, err)
+	// The injected line must not have become a real header.
+	test.Empty(parsed.Header.Get("Bcc"))
+	test.NotContains(srv.recipients(), "victim@tinymail.test")
+}


### PR DESCRIPTION
## Summary

Fixes from the last code review on the v0.9 work.

- Send CC/BCC recipients in the SMTP envelope (RCPT TO) so they actually receive the message
- Stop leaking Bcc addresses in message headers; deliver them via the envelope only
- Sanitize header values to prevent CRLF header injection
- Use RFC 5322 CRLF line endings throughout the serialized message
- Refuse to send LOGIN credentials over an unencrypted connection
- Normalize LOGIN challenges before matching (`Username:`/`username`/...)

## Tests

- Added `auth_test.go`, `mime_test.go`, `mock_smtp_test.go`, `send_test.go`
- Existing golden-string tests updated for CRLF output
- All 29 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)